### PR TITLE
Remove unneeded CI token, enable CodeQL, and add security policy

### DIFF
--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Rust Environment
-      uses: moonrepo/setup-rust@v1
+      uses: moonrepo/setup-rust@ede6de059f8046a5e236c94046823e2af11ca670 # v1
       with:
         components: clippy
         targets: aarch64-unknown-linux-gnu

--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -1,11 +1,6 @@
 name: "Build packages"
 description: "Build RPM and DEB packages for multiple architectures"
 
-inputs:
-  CI_PROTOBUF_ACCESS_TOKEN:
-    description: "Access token for protobuf repo"
-    required: true
-
 runs:
   using: "composite"
   steps:
@@ -28,10 +23,6 @@ runs:
         mkdir -p ${HOME}/zig
         tar -xJ -C ${HOME}/zig --strip-components=1 -f zig.tar.xz
         echo ${HOME}/zig >> ${GITHUB_PATH}
-    - name: Configure foreign git repos
-      # Make sure the runner has access to the protobuf repo using an access token
-      shell: bash
-      run: git config --global url."https://${{ inputs.CI_PROTOBUF_ACCESS_TOKEN }}@github.com/thinkparq/protobuf".insteadOf https://github.com/thinkparq/protobuf
     - name: Run checks and tests
       shell: bash
       run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,19 +1,25 @@
 name: Check
 run-name: Check ${{ github.ref_name }} by @${{ github.actor }}
-on: [pull_request, workflow_call]
+on:
+  pull_request:
+    paths-ignore:
+      - "**/*.md"
+  workflow_call:
 env:
   # Cargo must use git cli for checkouts instead of builtin functionality to respect the repla
   CARGO_NET_GIT_FETCH_WITH_CLI: true
 jobs:
   checks:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       CARGO_LOCKED: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Rust
-        uses: moonrepo/setup-rust@v1
+        uses: moonrepo/setup-rust@ede6de059f8046a5e236c94046823e2af11ca670 # v1
         with:
           components: clippy
           bins: cargo-deny

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,9 +21,6 @@ jobs:
         run: |
           rustup toolchain install nightly
           rustup component add --toolchain nightly rustfmt
-      - name: Configure foreign git repos
-        # Make sure the runner has access to the protobuf repo using an access token
-        run: git config --global url."https://${{ secrets.CI_PROTOBUF_ACCESS }}@github.com/thinkparq/protobuf".insteadOf https://github.com/thinkparq/protobuf
       - name: Checks
         run: make check
       - name: Run tests

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,102 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL Advanced"
+
+on:
+  push:
+    branches: ["main"]
+    paths-ignore:
+      - "**/*.md"
+  pull_request:
+    branches: ["main"]
+    paths-ignore:
+      - "**/*.md"
+  schedule:
+    - cron: "30 20 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    # Runner size impacts CodeQL analysis time. To learn more, please see:
+    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
+    #   - https://gh.io/supported-runners-and-hardware-resources
+    #   - https://gh.io/using-larger-runners (GitHub.com only)
+    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+        # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
+        # Use `c-cpp` to analyze code written in C, C++ or both
+        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
+        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
+        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
+        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
+        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
+        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Add any setup steps before running the `github/codeql-action/init` action.
+      # This includes steps like installing compilers or runtimes (`actions/setup-node`
+      # or others). This is typically only required for manual builds.
+      # - name: Setup runtime (example)
+      #   uses: actions/setup-example@v1
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+
+          # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
+
+      # If the analyze step fails for one of the languages you are analyzing with
+      # "We were unable to automatically build your code", modify the matrix above
+      # to set the build mode to "manual" for that language. Then modify this step
+      # to build your code.
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      - if: matrix.build-mode == 'manual'
+        shell: bash
+        run: |
+          echo 'If you are using a "manual" build mode for one or more of the' \
+            'languages you are analyzing, replace this with the commands to build' \
+            'your code, for example:'
+          echo '  make bootstrap'
+          echo '  make release'
+          exit 1
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,6 @@ jobs:
           fetch-depth: 0
       - name: Build Packages
         uses: ./.github/actions/package
-        with:
-          CI_PROTOBUF_ACCESS_TOKEN: ${{ secrets.CI_PROTOBUF_ACCESS }}
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v6
@@ -34,7 +32,7 @@ jobs:
         run: |
           cd target/package
           export GPG_TTY=$(tty)
-          gpg --pinentry-mode loopback --passphrase ${{ secrets.PUBLICREPO_GPGPACKAGEPASSPHRASE }} --trust-model always --detach-sign -o checksums.txt.sig -r packages@beegfs.com checksums.txt 
+          gpg --pinentry-mode loopback --passphrase ${{ secrets.PUBLICREPO_GPGPACKAGEPASSPHRASE }} --trust-model always --detach-sign -o checksums.txt.sig -r packages@beegfs.com checksums.txt
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
 env:
   # Cargo must use git cli for checkouts instead of builtin functionality to respect the repla
   CARGO_NET_GIT_FETCH_WITH_CLI: true
+permissions:
+  # Required to publish releases.
+  contents: write
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -24,7 +27,7 @@ jobs:
         uses: ./.github/actions/package
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@82a020f1f7f605c65dd2449b392a52c3fcfef7ef # v6
         with:
           gpg_private_key: ${{ secrets.PUBLICREPO_GPGPACKAGEKEY }}
           passphrase: ${{ secrets.PUBLICREPO_GPGPACKAGEPASSPHRASE }}
@@ -34,7 +37,7 @@ jobs:
           export GPG_TTY=$(tty)
           gpg --pinentry-mode loopback --passphrase ${{ secrets.PUBLICREPO_GPGPACKAGEPASSPHRASE }} --trust-model always --detach-sign -o checksums.txt.sig -r packages@beegfs.com checksums.txt
       - name: Create Release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1
         with:
           artifacts: "target/package/*.deb,target/package/*.rpm,target/package/checksums*"
           allowUpdates: true

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,62 @@
+# Security Policy <!-- omit in toc -->
+
+## Contents <!-- omit in toc -->
+
+- [How to Report](#how-to-report)
+- [Response and Handling](#response-and-handling)
+- [Disclosure Policy](#disclosure-policy)
+- [Supported Versions](#supported-versions)
+- [Prevention](#prevention)
+- [Acknowledgments](#acknowledgments)
+
+## How to Report
+
+* Please [report](https://github.com/ThinkParQ/beegfs-rust/security) potential security
+  vulnerabilities using [GitHub's private vulnerability
+  reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability).
+  Make sure to not disclose this information in public.
+* Provide a detailed description of the potential vulnerability, ensuring you include steps that can
+  help in reproducing the issue.
+
+## Response and Handling
+
+We will make every effort to response to and resolve security issues in a timely manner. To that end
+our goals when handling security issues are:
+
+* Acknowledge every report within three working days.
+* Assess the report, evaluate its impact and severity, and determine its authenticity providing an
+  new update within five working days.
+* Work diligently to address any verified vulnerabilities. While the time to deliver a fix will vary
+  depending on complexity, throughout this process, we'll provide timely updates on our progress
+  until resolution.
+* Once the vulnerability has been fixed, make a public announcement crediting you for the discovery
+  (unless you wish to remain anonymous).
+
+## Disclosure Policy
+
+Upon confirmation of a security issue, our approach is:
+
+1. Verify the vulnerability and determine affected versions.
+2. Develop a fix or a workaround.
+3. Upon a successful fix or workaround, inform the community through a public advisory.
+
+## Supported Versions
+
+Security fixes are made available in the latest major version and backported to older versions per
+the [BeeGFS support policy](https://github.com/ThinkParQ/beegfs/blob/master/SUPPORT.md)
+
+## Prevention
+
+To help prevent security vulnerabilities, we:
+
+- Regularly review and update our dependencies using Dependabot and CodeQL.
+  
+- Adhere to best coding practices and conduct regular code reviews.
+  
+- Actively seek feedback and input from our developer community on security matters.
+
+## Acknowledgments
+
+We're thankful to our community for their active involvement in enhancing the safety of our project.
+Those who've identified vulnerabilities are recognized in our release notes, unless they've opted
+for anonymity.


### PR DESCRIPTION
Makes the same change as were done [for Go](https://github.com/ThinkParQ/beegfs-go/pull/168). Note unfortunately CodeQL does not yet support Rust, so this only adds scanning for any issues with GitHub Actions workflows.