### PR TITLE
fix: remove --deb-revision flag incompatible with cargo-deb 3.x when using --deb-version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,11 +112,9 @@ package:
 	# Build packages
 	# These don't respect CARGO_BUILD_TARGET, so we need to add --target manually using $(TARGET_FLAG)
 	cargo deb --locked $(TARGET_FLAG) --no-build -p mgmtd -o $(PACKAGE_DIR)/ \
-		--deb-version="20:$(VERSION_TRIMMED)" \
-		--deb-revision=""
+		--deb-version="20:$(VERSION_TRIMMED)" 
 	cargo deb --locked $(TARGET_FLAG) --no-build -p mgmtd -o $(PACKAGE_DIR)/ --variant=debug \
-		--deb-version="20:$(VERSION_TRIMMED)" \
-		--deb-revision=""
+		--deb-version="20:$(VERSION_TRIMMED)" 
 
 	# We don't want the epoch in the file names
 	find $(PACKAGE_DIR) -name "*_20:*.deb" -exec bash -c 'mv "$$1" $$(echo "$$1" | sed "s/_20:/_/g")' bash {} \;


### PR DESCRIPTION
I checked the changes for default --deb-revision using the `dpkg -I package.deb` for old package and new package after removing the `--deb-revison` flag.

Old Package metadata
```
 new Debian package, version 2.0.
 size 3569700 bytes: control archive=376 bytes.
      30 bytes,     1 lines      conffiles
     280 bytes,    12 lines      control
 Package: beegfs-mgmtd
 Version: 20:8.1.0
 Architecture: amd64
 Homepage: https://www.beegfs.io
 Priority: optional
 Maintainer: ThinkParQ GmbH
 Installed-Size: 12197
 Depends:
 Suggests: libbeegfs-license (>= 8)
 Description: The BeeGFS management service
  The BeeGFS management service

```
New Package metadata
```
 new Debian package, version 2.0.
 size 3462190 bytes: control archive=380 bytes.
      30 bytes,     1 lines      conffiles
     280 bytes,    12 lines      control
 Package: beegfs-mgmtd
 Version: 20:8.1.0
 Architecture: amd64
 Homepage: https://www.beegfs.io
 Priority: optional
 Maintainer: ThinkParQ GmbH
 Installed-Size: 12080
 Depends:
 Suggests: libbeegfs-license (>= 8)
 Description: The BeeGFS management service
  The BeeGFS management service

```