### PR TITLE
feat: Add support for returning metadata root mirror node info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,7 +852,7 @@ dependencies = [
 [[package]]
 name = "protobuf"
 version = "0.0.0"
-source = "git+https://github.com/thinkparq/protobuf?rev=ecdf4dc4bc70bdf3db47e7d7a4d335f4a325f63e#ecdf4dc4bc70bdf3db47e7d7a4d335f4a325f63e"
+source = "git+https://github.com/thinkparq/protobuf?rev=24f942a79ffa8a879b84dc014384c9f06780d2b7#24f942a79ffa8a879b84dc014384c9f06780d2b7"
 dependencies = [
  "prost",
  "prost-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ itertools = "0"
 libc = "0"
 log = { version = "0", features = ["std"] }
 prost = "0"
-protobuf = { git = "https://github.com/thinkparq/protobuf", rev = "ecdf4dc4bc70bdf3db47e7d7a4d335f4a325f63e" }
+protobuf = { git = "https://github.com/thinkparq/protobuf", rev = "24f942a79ffa8a879b84dc014384c9f06780d2b7" }
 regex = "1"
 ring = "0"
 rusqlite = { version = "0", features = ["bundled", "vtab", "array"] }

--- a/mgmtd/src/grpc/node.rs
+++ b/mgmtd/src/grpc/node.rs
@@ -3,32 +3,30 @@ use shared::bee_msg::node::RemoveNode;
 
 /// Delivers a list of nodes
 pub(crate) async fn get(ctx: Context, req: pm::GetNodesRequest) -> Result<pm::GetNodesResponse> {
-    let (mut nodes, nics, meta_root_node, fs_uuid) = ctx
+    let (mut nodes, nics, meta_root_node, meta_root_buddy_group, fs_uuid) = ctx
         .db
         .read_tx(move |tx| {
             // Fetching the nic list is optional as it causes additional load
             let nics: Vec<(Uid, pm::get_nodes_response::node::Nic)> = if req.include_nics {
-                tx.prepare_cached(
-                    sql!(
-                        "SELECT nn.node_uid, nn.addr, n.port, nn.nic_type, nn.name
-                        FROM node_nics AS nn
-                        INNER JOIN nodes AS n USING(node_uid)
-                        ORDER BY nn.node_uid ASC"
-                    ))?.query_and_then(
-                    [],
-                    |row| {
-                        let nic_type = NicType::from_row(row, 3)?.into_proto_i32();
+                tx.prepare_cached(sql!(
+                    "SELECT nn.node_uid, nn.addr, n.port, nn.nic_type, nn.name
+                    FROM node_nics AS nn
+                    INNER JOIN nodes AS n USING(node_uid)
+                    ORDER BY nn.node_uid ASC"
+                ))?
+                .query_and_then([], |row| {
+                    let nic_type = NicType::from_row(row, 3)?.into_proto_i32();
 
-                        Ok((
-                            row.get(0)?,
-                            pm::get_nodes_response::node::Nic {
-                                addr: row.get(1)?,
-                                name: row.get(4)?,
-                                nic_type,
-                            },
-                        ))
-                    },
-                )?.collect::<Result<Vec<_>>>()?
+                    Ok((
+                        row.get(0)?,
+                        pm::get_nodes_response::node::Nic {
+                            addr: row.get(1)?,
+                            name: row.get(4)?,
+                            nic_type,
+                        },
+                    ))
+                })?
+                .collect::<Result<Vec<_>>>()?
             } else {
                 vec![]
             };
@@ -58,44 +56,79 @@ pub(crate) async fn get(ctx: Context, req: pm::GetNodesRequest) -> Result<pm::Ge
                 },
             )?;
 
-            // Figure out the meta root node
-            let meta_root_node = if let Some((uid, alias, num_id)) = tx
+            // Figure out the meta root node and buddy mirror information
+            let maybe_row = tx
                 .query_row_cached(
                     sql!(
                         "SELECT
-                        COALESCE(mn.node_uid, mn2.node_uid),
-                        COALESCE(e.alias, e2.alias),
-                        COALESCE(mn.node_id, mn2.node_id)
+                            COALESCE(mn.node_uid, mn2.node_uid),
+                            COALESCE(e.alias, e2.alias),
+                            COALESCE(mn.node_id, mn2.node_id),
+                            mg.group_id,
+                            mg.group_uid,
+                            ge.alias
                         FROM root_inode as ri
                         LEFT JOIN targets AS mt USING(node_type, target_id)
-                        LEFT JOIN nodes AS mn ON mn.node_id = mt.node_id AND mn.node_type = mt.node_type
+                        LEFT JOIN nodes AS mn ON mn.node_id = mt.node_id
+                            AND mn.node_type = mt.node_type
                         LEFT JOIN entities AS e ON e.uid = mn.node_uid
                         LEFT JOIN buddy_groups AS mg USING(node_type, group_id)
-                        LEFT JOIN targets AS mt2 ON mt2.target_id = mg.p_target_id AND mt2.node_type = mg.node_type
-                        LEFT JOIN nodes AS mn2 ON mn2.node_id = mt2.node_id AND mn2.node_type = mg.node_type
+                        LEFT JOIN entities AS ge ON ge.uid = mg.group_uid
+                        LEFT JOIN targets AS mt2 ON mt2.target_id = mg.p_target_id
+                            AND mt2.node_type = mg.node_type
+                        LEFT JOIN nodes AS mn2 ON mn2.node_id = mt2.node_id
+                            AND mn2.node_type = mg.node_type
                         LEFT JOIN entities AS e2 ON e2.uid = mn2.node_uid"
                     ),
                     [],
-                    |row| Ok((row.get(0)?, row.get::<_, String>(1)?, row.get(2)?)),
-                )
-                .optional()?
-            {
-                Some(EntityIdSet {
-                    uid,
-                    alias: alias.try_into()?,
-                    legacy_id: LegacyId {
-                        node_type: NodeType::Meta,
-                        num_id,
+                    |row| {
+                        Ok((
+                            row.get::<_, Uid>(0)?,
+                            row.get::<_, String>(1)?,
+                            row.get::<_, NodeId>(2)?,
+                            row.get::<_, Option<NodeId>>(3)?,
+                            row.get::<_, Option<Uid>>(4)?,
+                            row.get::<_, Option<String>>(5)?,
+                        ))
                     },
-                })
-            } else {
-                None
-            };
+                )
+                .optional()?;
+
+            let (meta_root_node, meta_root_buddy_group) =
+                if let Some((uid, alias, num_id, bg_num_id, bg_uid, bg_alias)) = maybe_row {
+                    let meta_root_node = Some(EntityIdSet {
+                        uid,
+                        alias: alias.try_into()?,
+                        legacy_id: LegacyId {
+                            node_type: NodeType::Meta,
+                            num_id,
+                        },
+                    });
+
+                    let meta_root_buddy_group = if let (Some(num_id), Some(uid), Some(alias)) =
+                        (bg_num_id, bg_uid, bg_alias)
+                    {
+                        Some(EntityIdSet {
+                            uid,
+                            alias: alias.try_into()?,
+                            legacy_id: LegacyId {
+                                node_type: NodeType::Meta,
+                                num_id,
+                            },
+                        })
+                    } else {
+                        None
+                    };
+
+                    (meta_root_node, meta_root_buddy_group)
+                } else {
+                    (None, None)
+                };
 
             let fs_uuid = db::config::get(tx, db::config::Config::FsUuid)
                 .context("Could not read file system UUID from database")?;
 
-            Ok((nodes, nics, meta_root_node, fs_uuid))
+            Ok((nodes, nics, meta_root_node, meta_root_buddy_group, fs_uuid))
         })
         .await?;
 
@@ -115,6 +148,7 @@ pub(crate) async fn get(ctx: Context, req: pm::GetNodesRequest) -> Result<pm::Ge
     Ok(pm::GetNodesResponse {
         nodes,
         meta_root_node: meta_root_node.map(|e| e.into()),
+        meta_root_buddy_group: meta_root_buddy_group.map(|e| e.into()),
         fs_uuid,
     })
 }


### PR DESCRIPTION
- Extend SQL in `query_row_cached` to pull buddy‐group’s `group_id`, `group_uid` and `alias.
- Introduce a second `Option<EntityIdSet>` (now named `meta_root_mirror`) alongside `meta_root_node.
- Match on nullable mirror columns so that if `group_id` and `uid` exist, we build the `EntityIdSet` (alias defaults to empty)

https://github.com/ThinkParQ/beegfs-go/issues/27

The changes required in the `protobuf` have been made in this PR:
https://github.com/ThinkParQ/protobuf/pull/55