### PR TITLE
fix: update cargo-generate-rpm and cargo-deb to latest version

### DIFF
--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -9,7 +9,7 @@ runs:
       with:
         components: clippy
         targets: aarch64-unknown-linux-gnu
-        bins: cargo-deny@0.18.3, cargo-about@0.7.1, cargo-generate-rpm@0.17.0, cargo-deb@3.3.0, cargo-zigbuild@0.20.1
+        bins: cargo-deny@0.18.3, cargo-about@0.7.1, cargo-generate-rpm@0.18.1, cargo-deb@3.6.0, cargo-zigbuild@0.20.1
     - name: Setup nightly toolchain and tools
       shell: bash
       run: |

--- a/Makefile
+++ b/Makefile
@@ -153,4 +153,4 @@ install-tools:
 	rustup update
 	rustup toolchain install nightly
 	rustup component add --toolchain nightly rustfmt
-	cargo install --locked cargo-deny@0.18.3 cargo-about@0.7.1 cargo-generate-rpm@0.17.0 cargo-deb@3.3.0
+	cargo install --locked cargo-deny@0.18.3 cargo-about@0.7.1 cargo-generate-rpm@0.18.1 cargo-deb@3.6.0


### PR DESCRIPTION
cargo-generate-rpm version 0.17 doesn't build anymore due to a dependency (cargo_toml) doing a breaking change in a patch release. 0.18.1 also fixes the bug that prevented it from working before.

Also update cargo-deb as well while we are on it.