### PR TITLE
Fall back to ipv4 if dual stack sockets are disabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,6 +1020,7 @@ dependencies = [
  "anyhow",
  "bee_serde_derive",
  "bytes",
+ "libc",
  "log",
  "pnet_datalink",
  "protobuf",

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -12,6 +12,7 @@ bee_serde_derive = { path = "../bee_serde_derive" }
 
 anyhow = { workspace = true }
 bytes = { workspace = true }
+libc = { workspace = true }
 log = { workspace = true }
 pnet_datalink = "0"
 protobuf = { workspace = true, optional = true }


### PR DESCRIPTION
Implement the same checks as in beegfs-core to have similar behavior: If dual stack is disabled (or ipv6 is enabled during boot but disabled at runtime), fall back to ipv4. 