### PR TITLE
Add --ipv6-disable setting

### DIFF
--- a/mgmtd/assets/beegfs-mgmtd.toml
+++ b/mgmtd/assets/beegfs-mgmtd.toml
@@ -62,10 +62,9 @@
 #
 # interfaces = ["*"]
 
-# Prefers an interfaces ipv6 addresses over ipv4.
-# By default, ipv4 addresses are preferred. If the interface filter is given, the interface
-# order has higher priority than the address family, which is sorted per interface.
-# interfaces_prefer_ipv6 = false
+
+# Force disable IPv6.
+# ipv6_disable = false,
 
 # Maximum number of outgoing connections per node.
 # connection-limit = 12

--- a/mgmtd/src/config.rs
+++ b/mgmtd/src/config.rs
@@ -232,6 +232,11 @@ generate_structs! {
     #[arg(value_parser = nic::NicFilter::parse)]
     interfaces: Vec<NicFilter> = vec![],
 
+    /// Force disable IPv6.
+    #[arg(long)]
+    #[arg(num_args = 0..=1, default_missing_value = "true")]
+    ipv6_disable: bool = false,
+
     /// Maximum number of outgoing BeeMsg connections per node. [default: 12]
     #[arg(long)]
     #[arg(value_name = "LIMIT")]

--- a/mgmtd/src/grpc.rs
+++ b/mgmtd/src/grpc.rs
@@ -16,7 +16,7 @@ use sqlite::{TransactionExt, check_affected_rows};
 use sqlite_check::sql;
 use std::fmt::Debug;
 use std::future::Future;
-use std::net::SocketAddr;
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::pin::Pin;
 use tonic::transport::{Identity, Server, ServerTlsConfig};
 use tonic::{Code, Request, Response, Status};
@@ -210,7 +210,14 @@ pub(crate) fn serve(ctx: Context, mut shutdown: RunStateHandle) -> Result<()> {
         },
     );
 
-    let serve_addr = shared::nic::select_bind_addr(ctx.info.user_config.grpc_port);
+    let serve_addr = SocketAddr::new(
+        if ctx.info.use_ipv6 {
+            Ipv6Addr::UNSPECIFIED.into()
+        } else {
+            Ipv4Addr::UNSPECIFIED.into()
+        },
+        ctx.info.user_config.grpc_port,
+    );
 
     log::info!("Serving gRPC requests on {serve_addr}");
 

--- a/mgmtd/src/main.rs
+++ b/mgmtd/src/main.rs
@@ -5,6 +5,7 @@ use mgmtd::db::{self};
 use mgmtd::license::LicenseVerifier;
 use mgmtd::{StaticInfo, start};
 use shared::journald_logger;
+use shared::nic::check_ipv6;
 use shared::types::AuthSecret;
 use std::backtrace::{Backtrace, BacktraceStatus};
 use std::fmt::Write;
@@ -97,7 +98,8 @@ doc.beegfs.io.",
         None
     };
 
-    let network_addrs = shared::nic::query_nics(&user_config.interfaces)?;
+    let use_ipv6 = check_ipv6(user_config.beemsg_port, !user_config.ipv6_disable);
+    let network_addrs = shared::nic::query_nics(&user_config.interfaces, use_ipv6)?;
 
     // Configure the tokio runtime
     let rt = tokio::runtime::Builder::new_multi_thread()
@@ -136,6 +138,7 @@ doc.beegfs.io.",
         // Start the actual daemon
         let run = start(
             StaticInfo {
+                use_ipv6,
                 user_config,
                 auth_secret,
                 network_addrs,


### PR DESCRIPTION
This disables ipv6 completely, overriding any --interfaces settings. It removes ipv6 interfaces from the managements reported nics, lets listeners use ipv4 sockets and ignores other nodes ipv6 nics on outgoing communication.

All of the above now also applies when ipv6 is automatically disabled.