### PR TITLE
fix(systemd): unit file was missing the requires directive

### DIFF
--- a/mgmtd/assets/beegfs-mgmtd.service
+++ b/mgmtd/assets/beegfs-mgmtd.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=BeeGFS Management Server
 Documentation=https://doc.beegfs.io
-After=network.target
+Requires=network-online.target 
+After=network-online.target
 
 [Service]
 Type=notify


### PR DESCRIPTION
This could cause the mgmtd to startup with only the loopback device advertised to other services.

This also switches to use network-online.target instead of network.target, consistent with the [BeeGFS 7 mgmtd](https://github.com/ThinkParQ/beegfs/blob/7.4.x/mgmtd/build/dist/usr/lib/systemd/system/beegfs-mgmtd.service).

Fixes https://github.com/ThinkParQ/beegfs/issues/80. 