### PR TITLE
Use github.ref_name in package action

### DIFF
--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -31,12 +31,14 @@ runs:
         make test
     - name: Build x86_64 packages
       env:
+        VERSION: {{ github.ref_name }}
         CARGO_TARGET: x86_64-unknown-linux-gnu
         GLIBC_VERSION: 2.27
       shell: bash
       run: make package
     - name: Build aarch64 packages
       env:
+        VERSION: {{ github.ref_name }}
         CARGO_TARGET: aarch64-unknown-linux-gnu
         BIN_UTIL_PREFIX: aarch64-linux-gnu-
         GLIBC_VERSION: 2.27

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 
 # Defines VERSION from the git history. Used by the binaries to build their own version string.
 # To satisfy semver we fall back to `0.0.0` if there is no matching tag
-VERSION := $(shell (git describe --tags --match "v*.*.*" 2>/dev/null || echo "v0.0.0") | sed 's/\-/~/g')
+VERSION ?= $(shell (git describe --tags --match "v*.*.*" 2>/dev/null || echo "v0.0.0") | sed 's/\-/~/g')
 # Strip the first character, which is usually "v" to allow usage in semver contexts
 VERSION_TRIMMED := $(shell V="$(VERSION)" && echo $${V:1})
 


### PR DESCRIPTION
Allows passing the VERSION setting to the Makefile. If not given, falls back to detection from git.

This should fix not choosing the latest tag for the version if there is more than one on the latest commit.