### PR TITLE
fix(packaging): mark toml config file as noreplace to prevent overwrite on upgrade

### DIFF
--- a/mgmtd/Cargo.toml
+++ b/mgmtd/Cargo.toml
@@ -68,7 +68,7 @@ assets = [
     { source = "target/release/beegfs-mgmtd", dest = "/opt/beegfs/sbin/", mode = "755" },
     { source = "target/release/thirdparty-licenses.html", dest = "/usr/share/doc/beegfs-mgmtd/", mode = "644" },
     { source = "assets/copyright", dest = "/usr/share/doc/beegfs-mgmtd/", mode = "644" },
-    { source = "assets/beegfs-mgmtd.toml", dest = "/etc/beegfs/", mode = "644", config = true },
+    { source = "assets/beegfs-mgmtd.toml", dest = "/etc/beegfs/", mode = "644", config = "noreplace" },
     { source = "assets/beegfs-mgmtd.service", dest = "/usr/lib/systemd/system/", mode = "644" },
 ]
 


### PR DESCRIPTION
Fixes https://github.com/ThinkParQ/beegfs/discussions/87

Before:

```
# rpm -q --qf $'%{FILENAMES}\t%{FILEFLAGS:fflags}\n' -l beegfs-mgmtd
/etc/beegfs/beegfs-mgmtd.toml	c
/etc/beegfs/beegfs-mgmtd.toml
/opt/beegfs/sbin/beegfs-mgmtd
/usr/lib/systemd/system/beegfs-mgmtd.service
/usr/share/doc/beegfs-mgmtd/copyright
/usr/share/doc/beegfs-mgmtd/thirdparty-licenses.html
```

After:

```
$ rpm -qpl --qf $'%{FILENAMES}\t%{FILEFLAGS:fflags}\n' target/package/beegfs-mgmtd-8.2.1-1.aarch64.rpm 
/etc/beegfs/beegfs-mgmtd.toml   cn
/etc/beegfs/beegfs-mgmtd.toml
/opt/beegfs/sbin/beegfs-mgmtd
/usr/lib/systemd/system/beegfs-mgmtd.service
/usr/share/doc/beegfs-mgmtd/copyright
/usr/share/doc/beegfs-mgmtd/thirdparty-licenses.html
```

Note no changes are needed for Debian packages as interactive upgrades should prompt on upgrades for modified config files and non-interactive upgrades should keep the local version (default behavior can be changed via apt config though).