### PR TITLE
fix(ci): configure release version based on github ref type.

### DIFF
--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -29,16 +29,20 @@ runs:
         make check
         make deny
         make test
+    - name: Configure release version
+      shell: bash
+      run: |
+        if [[ "${{ github.ref_type }}" == "tag" ]]; then
+          echo "VERSION=${{ github.ref_name }}" >> "$GITHUB_ENV"
+        fi
     - name: Build x86_64 packages
       env:
-        VERSION: ${{ github.ref_name }}
         CARGO_TARGET: x86_64-unknown-linux-gnu
         GLIBC_VERSION: 2.27
       shell: bash
       run: make package
     - name: Build aarch64 packages
       env:
-        VERSION: ${{ github.ref_name }}
         CARGO_TARGET: aarch64-unknown-linux-gnu
         BIN_UTIL_PREFIX: aarch64-linux-gnu-
         GLIBC_VERSION: 2.27


### PR DESCRIPTION
Package action had [started failing](https://github.com/ThinkParQ/beegfs-core/actions/runs/19020195808/job/54314010131) recently when the version was set to github_ref. 
The fix first checks if the github_ref is a tag then it sets the `VERSION` environment variable otherwise a version is generated using the older git tag and the git commit. 