### PR TITLE
Trigger storage pool refresh on buddy group and target deletions

### DIFF
--- a/mgmtd/src/grpc/target.rs
+++ b/mgmtd/src/grpc/target.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::cap_pool::{CapPoolCalculator, CapacityInfo};
 use shared::bee_msg::OpsErr;
 use shared::bee_msg::misc::RefreshCapacityPools;
+use shared::bee_msg::storage_pool::RefreshStoragePools;
 use shared::bee_msg::target::{
     RefreshTargetStates, SetTargetConsistencyStates, SetTargetConsistencyStatesResp,
 };
@@ -213,6 +214,14 @@ pub(crate) async fn delete(
             &ctx,
             &[NodeType::Meta],
             &RefreshCapacityPools { ack_id: "".into() },
+        )
+        .await;
+
+        // Storage targets deletion alter pool membership, so trigger an immediate pool refresh
+        notify_nodes(
+            &ctx,
+            &[NodeType::Meta, NodeType::Storage],
+            &RefreshStoragePools { ack_id: "".into() },
         )
         .await;
     }


### PR DESCRIPTION
Hi @rustybee42,

I was removing sleep statements in test cases and found out there was a test [create file stripping api](https://github.com/ThinkParQ/beegfs-core/blob/main/automation/tests_details/test_create_file_striping_api.py#L31C39-L31C50) which had sleep 310 sec. This was because the file striping took more than 5 minutes to take effect. The test only passed when there was a sleep of over 300 seconds; otherwise, the expected number of targets differed from the actual targets used for striping.

In the meta code it looks like in the [meta code](https://github.com/ThinkParQ/beegfs-core/blob/main/meta/source/components/InternodeSyncer.cpp#L86-L87) waits for 5 min for the first pass. We never refresh the storage‑pool definitions once mgmtd finally knows about the targets. 

With 7.4 version management we did not require this 300 sec sleep. So looks like we had to add this 5 min sleep in test case from 8.x release.

This PR implements notifications to refresh storage pools when stripping is changed,  buddy groups or targets are deleted, ensuring pool membership remains consistent.
