### PR TITLE
chore(ci): add option to only build single arch package

### DIFF
--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -1,5 +1,10 @@
 name: "Build packages"
 description: "Build RPM and DEB packages for multiple architectures"
+inputs:
+  build-targets:
+    description: "Set to x86_64, aarch64, or both to choose which packages to build"
+    required: false
+    default: both
 
 runs:
   using: "composite"
@@ -36,12 +41,14 @@ runs:
           echo "VERSION=${{ github.ref_name }}" >> "$GITHUB_ENV"
         fi
     - name: Build x86_64 packages
+      if: ${{ inputs.build-targets != 'aarch64' }}
       env:
         CARGO_TARGET: x86_64-unknown-linux-gnu
         GLIBC_VERSION: 2.27
       shell: bash
       run: make package
     - name: Build aarch64 packages
+      if: ${{ inputs.build-targets != 'x86_64' }}
       env:
         CARGO_TARGET: aarch64-unknown-linux-gnu
         BIN_UTIL_PREFIX: aarch64-linux-gnu-


### PR DESCRIPTION
This PR adds flexibility to choose which architecture packages to build, allowing non-release workflows to build only one architecture and significantly reducing build times.


**Build workflow improvements:**

* Added a new input parameter `build-targets` to `.github/actions/package/action.yml`, allowing users to specify which architectures (`x86_64`, `aarch64`, or both) to build.
* Updated the build steps to conditionally run the x86_64 or aarch64 package builds based on the value of the `build-targets` input.