### PR TITLE
ci: fix unsupported CVSS version: 4.0

### DIFF
--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -14,7 +14,7 @@ runs:
       with:
         components: clippy
         targets: aarch64-unknown-linux-gnu
-        bins: cargo-deny@0.18.3, cargo-about@0.7.1, cargo-generate-rpm@0.18.1, cargo-deb@3.6.0, cargo-zigbuild@0.20.1
+        bins: cargo-deny@0.18.9, cargo-about@0.7.1, cargo-generate-rpm@0.18.1, cargo-deb@3.6.0, cargo-zigbuild@0.20.1
     - name: Setup nightly toolchain and tools
       shell: bash
       run: |


### PR DESCRIPTION
Current version of cargo deny does not support CVSS version: 4.0.  Updated cargo deny package.

Fixes the following error. 
```
2025-12-23 07:33:16 [ERROR] failed to load advisory database: parse error: error parsing /home/runner/.cargo/advisory-dbs/advisory-db-3157b0e258782691/crates/cap-primitives/RUSTSEC-2024-0445.md: parse error: TOML parse error at line 8, column 8
  |
8 | cvss = "CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N"
  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
unsupported CVSS version: 4.0

make: *** [Makefile:48: deny] Error 1
Error: Process completed with exit code 2.
```